### PR TITLE
Fix deprecation warning when importing `errorban` internally

### DIFF
--- a/questionable/errorban.nim
+++ b/questionable/errorban.nim
@@ -1,10 +1,3 @@
 {.warning: "errorban is deprecated; use nimble package `upraises` instead".}
 
-## Include this file to indicate that your module does not raise Errors.
-## Disables compiler hints about unused declarations in Nim < 1.4.0
-
-when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
-  {.push raises:[].}
-else:
-  {.push raises: [Defect].}
-  {.hint[XDeclaredButNotUsed]: off.}
+include ./private/errorban

--- a/questionable/options.nim
+++ b/questionable/options.nim
@@ -6,7 +6,7 @@ import ./indexing
 import ./operators
 import ./without
 
-include ./errorban
+include ./private/errorban
 
 export options except get
 export binding

--- a/questionable/private/errorban.nim
+++ b/questionable/private/errorban.nim
@@ -1,0 +1,8 @@
+## Include this file to indicate that your module does not raise Errors.
+## Disables compiler hints about unused declarations in Nim < 1.4.0
+
+when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+  {.push raises:[].}
+else:
+  {.push raises: [Defect].}
+  {.hint[XDeclaredButNotUsed]: off.}

--- a/questionable/results.nim
+++ b/questionable/results.nim
@@ -8,7 +8,7 @@ import ./operators
 import ./without
 import ./withoutresult
 
-include ./errorban
+include ./private/errorban
 
 export resultsbase except ok, err, isOk, isErr, get
 export binding


### PR DESCRIPTION
When a user tries to `import questionable`, they receive a deprecation warning from inside the library, which they are not able to fix or even silence (without silencing all deprecations in their project). Nimble [recommends][private-modules] to keep private modules in a `private/` subdirectory, which is what this PR does.

[private-modules]: https://github.com/nim-lang/nimble#private-modules