### PR TITLE
Retrieve optional error from Result

### DIFF
--- a/questionable/results.nim
+++ b/questionable/results.nim
@@ -110,6 +110,14 @@ proc option*[T,E](value: Result[T,E]): ?T =
   else:
     T.none
 
+proc errorOption*[T, E](value: Result[T, E]): ?E =
+  ## Returns an Option that contains the error from the Result, if it has one.
+
+  if value.isErr:
+    value.error.some
+  else:
+    E.none
+
 Result.liftUnary(`-`)
 Result.liftUnary(`+`)
 Result.liftUnary(`@`)

--- a/testmodules/result/test.nim
+++ b/testmodules/result/test.nim
@@ -326,6 +326,12 @@ suite "result":
     check 42.success.option == 42.some
     check int.failure(error).option == int.none
 
+  test "Result error can be converted to Option":
+    check (int.failure(error).errorOption == error.some)
+    check (42.success.errorOption == (ref CatchableError).none)
+    check (void.failure(error).errorOption == error.some)
+    check (success().errorOption == (ref CatchableError).none)
+
   test "failure can be used without type parameter in procs":
     proc fails: ?!int =
       failure "some error"


### PR DESCRIPTION
Allows for error handling code that is only interested in the error part of a Result. For instance when dealing with `?!void` Results.

```nim
proc foo: ?!void =
  # do something that might fail

if error =? foo().errorOption:
  echo "something went wrong: ", error.msg
```