### PR TITLE
Disable warning about DotLikeOps

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,8 +1,13 @@
+# Style Check
 --styleCheck:usages
 if (NimMajor, NimMinor) < (1, 6):
   --styleCheck:hint
 else:
   --styleCheck:error
+
+# Disable some warnings
+if (NimMajor, NimMinor) >= (1, 6):
+  switch("warning", "DotLikeOps:off")
 
 # begin Nimble config (version 1)
 when fileExists("nimble.paths"):

--- a/questionable.nim
+++ b/questionable.nim
@@ -1,3 +1,4 @@
+import ./questionable/dotlike
 import ./questionable/options
 
 export options

--- a/questionable/dotlike.nim
+++ b/questionable/dotlike.nim
@@ -1,0 +1,2 @@
+when defined(nimPreviewDotLikeOps):
+  {.error: "DotLikeOps are not supported by questionable".}


### PR DESCRIPTION
Give a clear compiler error when questionable is used with the -d:nimPreviewDotLikeOps flag.

Reason: the option is likely to be deprecated or removed. More info:
https://github.com/nim-lang/Nim/pull/19919