### PR TITLE
Fix error when using an existing name as error variable

### DIFF
--- a/questionable/withoutresult.nim
+++ b/questionable/withoutresult.nim
@@ -2,11 +2,31 @@ import std/macros
 import ./without
 import ./private/binderror
 
-macro without*(condition, errorname, body): untyped =
+proc undoSymbolResolution(expression, ident: NimNode): NimNode =
+  ## Finds symbols in the expression that match the `ident` and replaces them
+  ## with `ident`, effectively undoing any symbol resolution that happened
+  ## before.
+
+  const symbolKinds = {nnkSym, nnkOpenSymChoice, nnkClosedSymChoice}
+
+  if expression.kind in symbolKinds and eqIdent($expression, $ident):
+    return ident
+
+  for i in 0..<expression.len:
+    expression[i] = undoSymbolResolution(expression[i], ident)
+
+  expression
+
+macro without*(condition, errorname, body: untyped): untyped =
   ## Used to place guards that ensure that a Result contains a value.
   ## Exposes error when Result does not contain a value.
 
   let errorIdent = ident $errorname
+
+  # Nim's early symbol resolution might have picked up a symbol with the
+  # same name as our error variable. We need to undo this to make sure that our
+  # error variable is seen.
+  let body = body.undoSymbolResolution(errorIdent)
 
   quote do:
     var error: ref CatchableError

--- a/questionable/withoutresult.nim
+++ b/questionable/withoutresult.nim
@@ -1,12 +1,16 @@
+import std/macros
 import ./without
 import ./private/binderror
 
-template without*(condition, errorname, body): untyped =
+macro without*(condition, errorname, body): untyped =
   ## Used to place guards that ensure that a Result contains a value.
   ## Exposes error when Result does not contain a value.
 
-  var error: ref CatchableError
+  let errorIdent = ident $errorname
 
-  without captureBindError(error, condition):
-    template errorname: ref CatchableError = error
-    body
+  quote do:
+    var error: ref CatchableError
+
+    without captureBindError(error, `condition`):
+      template `errorIdent`: ref CatchableError = error
+      `body`

--- a/testmodules/result/test.nim
+++ b/testmodules/result/test.nim
@@ -281,6 +281,15 @@ suite "result":
         check e2.msg == "error2"
       check e1.msg == "error1"
 
+  test "without statement works in generic code using existing error name":
+    let existingName {.used.} = "some variable"
+
+    proc shouldCompile(_: type int): ?!int =
+      without _ =? int.failure "error", existingName:
+        return success 42
+
+    discard int.shouldCompile()
+
   test "without statements with error work in nested calls":
     proc bar(): ?!int =
       without _ =? int.failure "error", err:

--- a/testmodules/result/test.nim
+++ b/testmodules/result/test.nim
@@ -286,6 +286,7 @@ suite "result":
 
     proc shouldCompile(_: type int): ?!int =
       without _ =? int.failure "error", existingName:
+        check existingName.msg == "error"
         return success 42
 
     discard int.shouldCompile()

--- a/testmodules/result/test.nim
+++ b/testmodules/result/test.nim
@@ -306,7 +306,8 @@ suite "result":
 
   test "without statement with error works in nested generic calls":
     proc works(_: type int): ?!int =
-      without _ =? int.failure "error1", err:
+      without _ =? int.failure "error1", error:
+        check error.msg == "error1"
         return success 42
 
     proc fails(_: type int): ?!int =


### PR DESCRIPTION
Using `without` in combination with generics and an existing name would result in a compiler error. 

Example:
```nim
let existingName {.used.} = "some variable"

proc shouldCompile(_: type int): ?!int =
  without _ =? int.failure "error", existingName: # compiler error
     # ...

```

Fixes #19