### PR TITLE
Fix redefinition of 'T`gensymXX' error

### DIFF
--- a/questionable/indexing.nim
+++ b/questionable/indexing.nim
@@ -4,8 +4,9 @@ macro `.?`*(expression: typed, brackets: untyped{nkBracket}): untyped =
   # chain is of shape: expression.?[index]
   let index = brackets[0]
   quote do:
-    type T = typeof(`expression`[`index`])
-    try:
-      `expression`[`index`].some
-    except KeyError:
-      T.none
+    block:
+      type T = typeof(`expression`[`index`])
+      try:
+        `expression`[`index`].some
+      except KeyError:
+        T.none


### PR DESCRIPTION
In rare instances, the Nim compiler will generate the same symbol more than once. Adding a `block` works around this issue.

Reproducing this behavior in a unit test has proved elusive.